### PR TITLE
Add mybinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # fiftyfizzbuzzes
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/vihart/fiftyfizzbuzzes/master?filepath=Fifty%20Fizzbuzzes.ipynb)
+
 Fifty different implementations of Fizzbuzz in Python.
 Uses jupyter notebook 5.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: fizzbuzzes 
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - numpy
+  - matplotlib
+  - scikit-learn
+  - pandas
+  - ipywidgets


### PR DESCRIPTION
This PR adds a `mybinder` badge to the README.md for easy notebook launch and an `environment.yml`.  The `environment.yml` defines the Python dependencies necessary to execute the notebook